### PR TITLE
Add simple login and registration

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const session = require('express-session');
 const { createServer } = require('node:http');
 const { join } = require('node:path');
 
@@ -7,6 +8,7 @@ const { Server } = require('socket.io');
 
 // simple JSON persistence for players
 const db = require('./db');
+const authRoutes = require('./routes/auth');
 
 const app = express();
 const server = createServer(app);
@@ -14,7 +16,18 @@ const io = new Server(server, { pingInterval: 2000, pingTimeout: 5000 });
 
 const port = process.env.PORT || 3000;
 
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(
+  session({
+    secret: 'keyboard cat',
+    resave: false,
+    saveUninitialized: false
+  })
+);
+
 app.use(express.static('public'));
+app.use(authRoutes);
 
 app.get('/', (req, res) => {
   res.sendFile(join(__dirname, 'public', 'index.html'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,13 @@
 {
-  "name": "multiplayer-game-starter",
+  "name": "mp-base-game",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
+        "bcrypt": "^6.0.0",
         "express": "4.18.2",
+        "express-session": "^1.18.1",
         "socket.io": "4.6.1"
       }
     },
@@ -58,6 +60,20 @@
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "engines": {
         "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/body-parser": {
@@ -296,6 +312,40 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -472,6 +522,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
+      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -495,6 +565,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -536,6 +615,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -770,6 +858,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "express": "4.18.2",
+    "express-session": "^1.18.1",
     "socket.io": "4.6.1"
   }
 }

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Login</title>
+    <link rel="stylesheet" href="./styles/style.css" />
+  </head>
+  <body>
+    <div id="lobby">
+      <form id="loginForm" method="POST" action="/login">
+        <input name="username" type="text" placeholder="Username" style="width:100%; margin-bottom:4px; padding:4px" />
+        <input name="password" type="password" placeholder="Password" style="width:100%; margin-bottom:4px; padding:4px" />
+        <button type="submit" style="width:100%">Login</button>
+      </form>
+      <a href="/register.html" style="color:white">Register</a>
+    </div>
+  </body>
+</html>

--- a/public/register.html
+++ b/public/register.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Register</title>
+    <link rel="stylesheet" href="./styles/style.css" />
+  </head>
+  <body>
+    <div id="lobby">
+      <form id="registerForm" method="POST" action="/register">
+        <input name="username" type="text" placeholder="Username" style="width:100%; margin-bottom:4px; padding:4px" />
+        <input name="password" type="password" placeholder="Password" style="width:100%; margin-bottom:4px; padding:4px" />
+        <button type="submit" style="width:100%">Register</button>
+      </form>
+      <a href="/login.html" style="color:white">Login</a>
+    </div>
+  </body>
+</html>

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const db = require('../db');
+
+const router = express.Router();
+
+router.post('/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ message: 'Username and password required' });
+  }
+
+  const existing = db.getPlayer(username);
+  if (existing && existing.passwordHash) {
+    return res.status(400).json({ message: 'User already exists' });
+  }
+
+  const passwordHash = await bcrypt.hash(password, 10);
+  db.createPlayer(username, passwordHash);
+  res.json({ message: 'Registered' });
+});
+
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  const player = db.getPlayer(username);
+  if (!player || !player.passwordHash) {
+    return res.status(400).json({ message: 'Invalid credentials' });
+  }
+  const match = await bcrypt.compare(password, player.passwordHash);
+  if (!match) {
+    return res.status(400).json({ message: 'Invalid credentials' });
+  }
+
+  // set session
+  req.session.user = { username };
+  res.json({ message: 'Logged in' });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- install `bcrypt` and `express-session`
- create authentication router with `/register` and `/login`
- configure express to use JSON parsing and sessions
- serve new `login.html` and `register.html` pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68448d7f59c0832aa8e87612a560f69a