### PR TITLE
Add basic quest tracking

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -9,6 +9,7 @@ const { Server } = require('socket.io');
 // simple JSON persistence for players
 const db = require('./db');
 const authRoutes = require('./routes/auth');
+const questRoutes = require('./routes/quests');
 
 const app = express();
 const server = createServer(app);
@@ -28,6 +29,7 @@ app.use(
 
 app.use(express.static('public'));
 app.use(authRoutes);
+app.use(questRoutes);
 
 app.get('/', (req, res) => {
   res.sendFile(join(__dirname, 'public', 'index.html'));

--- a/db.js
+++ b/db.js
@@ -53,11 +53,16 @@ function updateQuestState(username, questState) {
   }
 }
 
+function getQuestState(username) {
+  return players[username]?.questState || {};
+}
+
 module.exports = {
   loadPlayers,
   savePlayers,
   getPlayer,
   createPlayer,
   updateScore,
-  updateQuestState
+  updateQuestState,
+  getQuestState
 };

--- a/models/quest.js
+++ b/models/quest.js
@@ -1,0 +1,13 @@
+const quests = [
+  { id: 'practice', description: 'Play a game', goal: 1 },
+  { id: 'shooter', description: 'Shoot 10 projectiles', goal: 10 },
+  { id: 'winner', description: 'Reach 5 points', goal: 5 }
+];
+
+function getQuests() {
+  return quests;
+}
+
+module.exports = {
+  getQuests
+};

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
     <h1 id="caption" style="display:none">MP Game</h1>
     <div id="lobby">
       <div id="gamesList"></div>
+      <div id="questsList" style="margin-top:10px;"></div>
       <form id="createGameForm" style="margin-top: 10px;">
         <input
           id="gameNameInput"
@@ -63,5 +64,6 @@
     <script src="./js/main.js"></script>
     <script src="./js/utils.js"></script>
     <script src="./js/lobby.js"></script>
+    <script src="./js/quests.js"></script>
   </body>
 </html>

--- a/public/js/quests.js
+++ b/public/js/quests.js
@@ -1,0 +1,38 @@
+let currentQuestState = {};
+
+async function loadQuests() {
+  const res = await fetch('/quests');
+  const data = await res.json();
+  currentQuestState = data.questState || {};
+  renderQuests(data.quests, currentQuestState);
+}
+
+function renderQuests(quests, questState) {
+  const container = document.getElementById('questsList');
+  if (!container) return;
+  container.innerHTML = '';
+  quests.forEach((q) => {
+    const div = document.createElement('div');
+    const progress = questState[q.id] || 0;
+    div.innerHTML = `${q.description} : <span data-id="${q.id}">${progress}/${q.goal}</span>`;
+    const btn = document.createElement('button');
+    btn.textContent = '+';
+    btn.addEventListener('click', () => {
+      const newState = { ...currentQuestState, [q.id]: progress + 1 };
+      updateQuests(newState);
+    });
+    div.appendChild(btn);
+    container.appendChild(div);
+  });
+}
+
+async function updateQuests(state) {
+  await fetch('/quests/update', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ questState: state })
+  });
+  loadQuests();
+}
+
+document.addEventListener('DOMContentLoaded', loadQuests);

--- a/routes/quests.js
+++ b/routes/quests.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const db = require('../db');
+const quests = require('../models/quest');
+
+const router = express.Router();
+
+router.get('/quests', (req, res) => {
+  const username = req.session.user?.username;
+  const questState = username ? db.getQuestState(username) : {};
+  res.json({ quests: quests.getQuests(), questState });
+});
+
+router.post('/quests/update', (req, res) => {
+  const username = req.session.user?.username;
+  if (!username) {
+    return res.status(401).json({ message: 'Not logged in' });
+  }
+  const questState = req.body.questState;
+  if (typeof questState !== 'object') {
+    return res.status(400).json({ message: 'Invalid quest state' });
+  }
+  db.updateQuestState(username, questState);
+  res.json({ message: 'Updated' });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- introduce `models/quest.js` with sample quests
- persist player quest state in DB with helpers
- expose `/quests` and `/quests/update` API routes
- register the new router in the server
- show quests on the lobby page with a minimal UI and update logic

## Testing
- `npm install`
- `node backend.js` *(server started and logged output)*

------
https://chatgpt.com/codex/tasks/task_e_68449319e17c832ab0842b780839c6f7