### PR TITLE
Fix scoreboard DOM updates and add HTML sanitization utility

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -103,6 +103,8 @@
     <script src="./js/classes/Particle.js"></script>
     <script src="./js/classes/Projectile.js"></script>
 
+    <script src="./js/sanitizeHtml.js"></script>
+
     <script src="./js/frontend.js"></script>
     <script src="./js/eventListeners.js"></script>
   </body>

--- a/public/js/frontend.js
+++ b/public/js/frontend.js
@@ -35,17 +35,16 @@ socket.on('updatePlayers', (backendPlayers) => {
         color: backendPlayer.color,
         username: backendPlayer.username
       });
-      document.querySelector(
-        '#playerLabels'
-      ).innerHTML += `<div data-id="${id}" data-score="${backendPlayer.score}">${backendPlayer.username} : ${backendPlayer.score}</div>`;
+      const label = document.createElement('div');
+      label.dataset.id = id;
+      label.dataset.score = backendPlayer.score;
+      label.textContent = `${backendPlayer.username} : ${backendPlayer.score}`;
+      document.querySelector('#playerLabels').appendChild(label);
     } else {
       // Player exist
-      document.querySelector(
-        `div[data-id="${id}"]`
-      ).innerHTML = `${backendPlayer.username} : ${backendPlayer.score}`;
-      document
-        .querySelector(`div[data-id="${id}"]`)
-        .setAttribute('data-score', backendPlayer.score);
+      const label = document.querySelector(`div[data-id="${id}"]`);
+      label.dataset.score = backendPlayer.score;
+      label.textContent = `${backendPlayer.username} : ${backendPlayer.score}`;
 
       const parentDiv = document.querySelector('#playerLabels');
       const childDivs = Array.from(parentDiv.querySelectorAll('div'));

--- a/public/js/sanitizeHtml.js
+++ b/public/js/sanitizeHtml.js
@@ -1,0 +1,13 @@
+function sanitizeHtml(str) {
+  if (typeof str !== 'string') return str;
+  return str.replace(/[&<>"']/g, function (tag) {
+    const chars = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    };
+    return chars[tag] || tag;
+  });
+}


### PR DESCRIPTION
## Summary
- add a small `sanitizeHtml` helper for escaping HTML
- load the helper script on the game page
- avoid using `innerHTML` in `frontend.js` when rendering the leaderboard

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6844944c6390832a9533ca641b1b9296