### PR TITLE
Initialize input sequence numbers at start

### DIFF
--- a/frontend/public/js/frontend.js
+++ b/frontend/public/js/frontend.js
@@ -190,7 +190,8 @@ const keys = {
 
 const SPEED = 5;
 const playerInputs = [];
-let sequenceNumber;
+// Start the input sequence numbering at zero so the server and client stay in sync
+let sequenceNumber = 0;
 setInterval(() => {
   if (keys.w.pressed) {
     sequenceNumber++;


### PR DESCRIPTION
## Summary
- initialize `sequenceNumber` in the frontend so the counter starts at 0

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867ac5c5234832abe8ecb9fc736e43d