### PR TITLE
Centralize guest name list

### DIFF
--- a/backend/routes/game.js
+++ b/backend/routes/game.js
@@ -2,29 +2,8 @@ const express = require('express');
 const gameConfig = require('../../shared/gameConfig');
 const router = express.Router();
 
-// Guest name pool - sci-fi themed names
-const GUEST_NAMES = [
-  'Nebula', 'Orion', 'Vega', 'Sirius', 'Altair', 'Rigel', 'Polaris', 'Castor', 'Pollux', 'Andromeda',
-  'Galaxy', 'Cosmos', 'Stellar', 'Nova', 'Comet', 'Meteor', 'Asteroid', 'Quasar', 'Pulsar', 'Neutron',
-  'Phoenix', 'Dragon', 'Falcon', 'Eagle', 'Hawk', 'Raven', 'Wolf', 'Tiger', 'Lion', 'Panther',
-  'Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta', 'Theta', 'Iota', 'Kappa',
-  'Cipher', 'Matrix', 'Vector', 'Pixel', 'Binary', 'Quantum', 'Photon', 'Electron', 'Proton', 'Neutron',
-  'Titan', 'Atlas', 'Hermes', 'Apollo', 'Artemis', 'Athena', 'Zeus', 'Poseidon', 'Hades', 'Ares',
-  'Crimson', 'Azure', 'Violet', 'Emerald', 'Golden', 'Silver', 'Platinum', 'Diamond', 'Ruby', 'Sapphire',
-  'Storm', 'Thunder', 'Lightning', 'Blizzard', 'Tornado', 'Hurricane', 'Cyclone', 'Typhoon', 'Monsoon', 'Gale',
-  'Shadow', 'Ghost', 'Phantom', 'Specter', 'Wraith', 'Spirit', 'Soul', 'Echo', 'Mirage', 'Illusion',
-  'Blade', 'Sword', 'Spear', 'Arrow', 'Shield', 'Armor', 'Helmet', 'Gauntlet', 'Boot', 'Cloak',
-  'Fire', 'Ice', 'Earth', 'Air', 'Water', 'Metal', 'Wood', 'Light', 'Dark', 'Void',
-  'Hunter', 'Ranger', 'Scout', 'Warrior', 'Knight', 'Paladin', 'Rogue', 'Assassin', 'Mage', 'Wizard',
-  'Ace', 'Chief', 'Major', 'Captain', 'Admiral', 'General', 'Marshal', 'Commander', 'Leader', 'Boss',
-  'Cyber', 'Tech', 'Data', 'Code', 'Hack', 'Link', 'Node', 'Grid', 'Net', 'Web',
-  'Star', 'Moon', 'Sun', 'Earth', 'Mars', 'Venus', 'Jupiter', 'Saturn', 'Uranus', 'Neptune',
-  'Apex', 'Prime', 'Ultra', 'Super', 'Mega', 'Giga', 'Tera', 'Peta', 'Exa', 'Zetta',
-  'Frost', 'Flame', 'Spark', 'Bolt', 'Charge', 'Surge', 'Pulse', 'Wave', 'Beam', 'Ray',
-  'Viper', 'Cobra', 'Python', 'Boa', 'Mamba', 'Adder', 'Asp', 'Krait', 'Taipan', 'Coral',
-  'Laser', 'Plasma', 'Fusion', 'Fission', 'Atomic', 'Nuclear', 'Particle', 'Molecule', 'Atom', 'Ion',
-  'Turbo', 'Nitro', 'Boost', 'Rush', 'Speed', 'Swift', 'Flash', 'Dash', 'Zoom', 'Blur'
-];
+// Sci-fi themed guest names shared between frontend and backend
+const GUEST_NAMES = require('../../shared/guestNames');
 
 // Keep track of used guest names
 const usedGuestNames = new Set();

--- a/backend/socket/SocketHandler.js
+++ b/backend/socket/SocketHandler.js
@@ -196,28 +196,7 @@ class SocketHandler {
 
   // Helper method to check if a username is a guest name
   isGuestName(username) {
-    const guestNames = [
-      'Nebula', 'Orion', 'Vega', 'Sirius', 'Altair', 'Rigel', 'Polaris', 'Castor', 'Pollux', 'Andromeda',
-      'Galaxy', 'Cosmos', 'Stellar', 'Nova', 'Comet', 'Meteor', 'Asteroid', 'Quasar', 'Pulsar', 'Neutron',
-      'Phoenix', 'Dragon', 'Falcon', 'Eagle', 'Hawk', 'Raven', 'Wolf', 'Tiger', 'Lion', 'Panther',
-      'Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta', 'Theta', 'Iota', 'Kappa',
-      'Cipher', 'Matrix', 'Vector', 'Pixel', 'Binary', 'Quantum', 'Photon', 'Electron', 'Proton',
-      'Titan', 'Atlas', 'Hermes', 'Apollo', 'Artemis', 'Athena', 'Zeus', 'Poseidon', 'Hades', 'Ares',
-      'Crimson', 'Azure', 'Violet', 'Emerald', 'Golden', 'Silver', 'Platinum', 'Diamond', 'Ruby', 'Sapphire',
-      'Storm', 'Thunder', 'Lightning', 'Blizzard', 'Tornado', 'Hurricane', 'Cyclone', 'Typhoon', 'Monsoon', 'Gale',
-      'Shadow', 'Ghost', 'Phantom', 'Specter', 'Wraith', 'Spirit', 'Soul', 'Echo', 'Mirage', 'Illusion',
-      'Blade', 'Sword', 'Spear', 'Arrow', 'Shield', 'Armor', 'Helmet', 'Gauntlet', 'Boot', 'Cloak',
-      'Fire', 'Ice', 'Earth', 'Air', 'Water', 'Metal', 'Wood', 'Light', 'Dark', 'Void',
-      'Hunter', 'Ranger', 'Scout', 'Warrior', 'Knight', 'Paladin', 'Rogue', 'Assassin', 'Mage', 'Wizard',
-      'Ace', 'Chief', 'Major', 'Captain', 'Admiral', 'General', 'Marshal', 'Commander', 'Leader', 'Boss',
-      'Cyber', 'Tech', 'Data', 'Code', 'Hack', 'Link', 'Node', 'Grid', 'Net', 'Web',
-      'Star', 'Moon', 'Sun', 'Earth', 'Mars', 'Venus', 'Jupiter', 'Saturn', 'Uranus', 'Neptune',
-      'Apex', 'Prime', 'Ultra', 'Super', 'Mega', 'Giga', 'Tera', 'Peta', 'Exa', 'Zetta',
-      'Frost', 'Flame', 'Spark', 'Bolt', 'Charge', 'Surge', 'Pulse', 'Wave', 'Beam', 'Ray',
-      'Viper', 'Cobra', 'Python', 'Boa', 'Mamba', 'Adder', 'Asp', 'Krait', 'Taipan', 'Coral',
-      'Laser', 'Plasma', 'Fusion', 'Fission', 'Atomic', 'Nuclear', 'Particle', 'Molecule', 'Atom', 'Ion',
-      'Turbo', 'Nitro', 'Boost', 'Rush', 'Speed', 'Swift', 'Flash', 'Dash', 'Zoom', 'Blur'
-    ];
+    const guestNames = require('../../shared/guestNames');
     
     // Check if username matches a guest name pattern (name or name with number)
     const baseUsername = username.replace(/\d+$/, '');

--- a/frontend/public/js/login.js
+++ b/frontend/public/js/login.js
@@ -1,26 +1,5 @@
-// Guest name pool - sci-fi themed names
-const GUEST_NAMES = [
-  'Nebula', 'Orion', 'Vega', 'Sirius', 'Altair', 'Rigel', 'Polaris', 'Castor', 'Pollux', 'Andromeda',
-  'Galaxy', 'Cosmos', 'Stellar', 'Nova', 'Comet', 'Meteor', 'Asteroid', 'Quasar', 'Pulsar', 'Neutron',
-  'Phoenix', 'Dragon', 'Falcon', 'Eagle', 'Hawk', 'Raven', 'Wolf', 'Tiger', 'Lion', 'Panther',
-  'Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta', 'Theta', 'Iota', 'Kappa',
-  'Cipher', 'Matrix', 'Vector', 'Pixel', 'Binary', 'Quantum', 'Photon', 'Electron', 'Proton', 'Neutron',
-  'Titan', 'Atlas', 'Hermes', 'Apollo', 'Artemis', 'Athena', 'Zeus', 'Poseidon', 'Hades', 'Ares',
-  'Crimson', 'Azure', 'Violet', 'Emerald', 'Golden', 'Silver', 'Platinum', 'Diamond', 'Ruby', 'Sapphire',
-  'Storm', 'Thunder', 'Lightning', 'Blizzard', 'Tornado', 'Hurricane', 'Cyclone', 'Typhoon', 'Monsoon', 'Gale',
-  'Shadow', 'Ghost', 'Phantom', 'Specter', 'Wraith', 'Spirit', 'Soul', 'Echo', 'Mirage', 'Illusion',
-  'Blade', 'Sword', 'Spear', 'Arrow', 'Shield', 'Armor', 'Helmet', 'Gauntlet', 'Boot', 'Cloak',
-  'Fire', 'Ice', 'Earth', 'Air', 'Water', 'Metal', 'Wood', 'Light', 'Dark', 'Void',
-  'Hunter', 'Ranger', 'Scout', 'Warrior', 'Knight', 'Paladin', 'Rogue', 'Assassin', 'Mage', 'Wizard',
-  'Ace', 'Chief', 'Major', 'Captain', 'Admiral', 'General', 'Marshal', 'Commander', 'Leader', 'Boss',
-  'Cyber', 'Tech', 'Data', 'Code', 'Hack', 'Link', 'Node', 'Grid', 'Net', 'Web',
-  'Star', 'Moon', 'Sun', 'Earth', 'Mars', 'Venus', 'Jupiter', 'Saturn', 'Uranus', 'Neptune',
-  'Apex', 'Prime', 'Ultra', 'Super', 'Mega', 'Giga', 'Tera', 'Peta', 'Exa', 'Zetta',
-  'Frost', 'Flame', 'Spark', 'Bolt', 'Charge', 'Surge', 'Pulse', 'Wave', 'Beam', 'Ray',
-  'Viper', 'Cobra', 'Python', 'Boa', 'Mamba', 'Adder', 'Asp', 'Krait', 'Taipan', 'Coral',
-  'Laser', 'Plasma', 'Fusion', 'Fission', 'Atomic', 'Nuclear', 'Particle', 'Molecule', 'Atom', 'Ion',
-  'Turbo', 'Nitro', 'Boost', 'Rush', 'Speed', 'Swift', 'Flash', 'Dash', 'Zoom', 'Blur'
-];
+// Sci-fi themed guest names shared with the backend
+import GUEST_NAMES from '../../../shared/guestNames.js';
 
 async function postJSON(url, data) {
   const res = await fetch(url, {

--- a/shared/guestNames.js
+++ b/shared/guestNames.js
@@ -1,0 +1,22 @@
+module.exports = [
+  'Nebula', 'Orion', 'Vega', 'Sirius', 'Altair', 'Rigel', 'Polaris', 'Castor', 'Pollux', 'Andromeda',
+  'Galaxy', 'Cosmos', 'Stellar', 'Nova', 'Comet', 'Meteor', 'Asteroid', 'Quasar', 'Pulsar', 'Neutron',
+  'Phoenix', 'Dragon', 'Falcon', 'Eagle', 'Hawk', 'Raven', 'Wolf', 'Tiger', 'Lion', 'Panther',
+  'Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta', 'Theta', 'Iota', 'Kappa',
+  'Cipher', 'Matrix', 'Vector', 'Pixel', 'Binary', 'Quantum', 'Photon', 'Electron', 'Proton', 'Neutron',
+  'Titan', 'Atlas', 'Hermes', 'Apollo', 'Artemis', 'Athena', 'Zeus', 'Poseidon', 'Hades', 'Ares',
+  'Crimson', 'Azure', 'Violet', 'Emerald', 'Golden', 'Silver', 'Platinum', 'Diamond', 'Ruby', 'Sapphire',
+  'Storm', 'Thunder', 'Lightning', 'Blizzard', 'Tornado', 'Hurricane', 'Cyclone', 'Typhoon', 'Monsoon', 'Gale',
+  'Shadow', 'Ghost', 'Phantom', 'Specter', 'Wraith', 'Spirit', 'Soul', 'Echo', 'Mirage', 'Illusion',
+  'Blade', 'Sword', 'Spear', 'Arrow', 'Shield', 'Armor', 'Helmet', 'Gauntlet', 'Boot', 'Cloak',
+  'Fire', 'Ice', 'Earth', 'Air', 'Water', 'Metal', 'Wood', 'Light', 'Dark', 'Void',
+  'Hunter', 'Ranger', 'Scout', 'Warrior', 'Knight', 'Paladin', 'Rogue', 'Assassin', 'Mage', 'Wizard',
+  'Ace', 'Chief', 'Major', 'Captain', 'Admiral', 'General', 'Marshal', 'Commander', 'Leader', 'Boss',
+  'Cyber', 'Tech', 'Data', 'Code', 'Hack', 'Link', 'Node', 'Grid', 'Net', 'Web',
+  'Star', 'Moon', 'Sun', 'Earth', 'Mars', 'Venus', 'Jupiter', 'Saturn', 'Uranus', 'Neptune',
+  'Apex', 'Prime', 'Ultra', 'Super', 'Mega', 'Giga', 'Tera', 'Peta', 'Exa', 'Zetta',
+  'Frost', 'Flame', 'Spark', 'Bolt', 'Charge', 'Surge', 'Pulse', 'Wave', 'Beam', 'Ray',
+  'Viper', 'Cobra', 'Python', 'Boa', 'Mamba', 'Adder', 'Asp', 'Krait', 'Taipan', 'Coral',
+  'Laser', 'Plasma', 'Fusion', 'Fission', 'Atomic', 'Nuclear', 'Particle', 'Molecule', 'Atom', 'Ion',
+  'Turbo', 'Nitro', 'Boost', 'Rush', 'Speed', 'Swift', 'Flash', 'Dash', 'Zoom', 'Blur'
+];


### PR DESCRIPTION
## Summary
- share guest name list across frontend and backend
- load guest names in game routes and socket handler from shared file
- import guest names in login script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867ae004b58832a8b08f1d49edae008