### PR TITLE
Use config projectile speed and test it

### DIFF
--- a/backend/services/GameService.js
+++ b/backend/services/GameService.js
@@ -150,7 +150,7 @@ class GameService {
     // Calculate velocity from angle if angle is provided
     let velocity;
     if (projectileData.angle !== undefined) {
-      const speed = 5; // projectile speed
+      const speed = config.game.projectileSpeed;
       velocity = {
         x: Math.cos(projectileData.angle) * speed,
         y: Math.sin(projectileData.angle) * speed

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -52,4 +52,26 @@ describe('Project Tests', function () {
     assert.ok(config.game, 'Config should have game section');
     assert.ok(config.database, 'Config should have database section');
   });
+
+  it('uses config projectile speed when creating projectiles', function () {
+    const GameService = require('../backend/services/GameService');
+    const config = require('../backend/config');
+    const service = new GameService();
+
+    const gameId = 'game1';
+    const socketId = 'socket1';
+    service.createGame(gameId, 'Test Game', 'owner');
+    service.addPlayerToGame(gameId, socketId, {
+      username: 'owner',
+      width: 100,
+      height: 100
+    });
+
+    const projectile = service.createProjectile(gameId, socketId, { angle: 0 });
+    assert.strictEqual(
+      projectile.velocity.x,
+      config.game.projectileSpeed,
+      'Projectile should use configured speed'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- import config into `GameService`
- reference `config.game.projectileSpeed` when creating projectiles
- test that projectile speed uses configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867bbca27a4832abe20f68f762f2481