### PR TITLE
Add per-game tick timers

### DIFF
--- a/backend/config/index.js
+++ b/backend/config/index.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 const gameConfig = require('../../shared/gameConfig');
+const { GAME_CONSTANTS } = require('../../shared/constants');
 
 const config = {
   server: {
@@ -16,6 +17,7 @@ const config = {
     projectileRadius: 5,
     maxPlayersPerGame: gameConfig.MAX_PLAYERS_PER_GAME,
     projectileSpeed: gameConfig.PROJECTILE_SPEED,
+    tickRate: GAME_CONSTANTS.TICK_RATE,
     canvasDefaults: {
       width: gameConfig.MAP_WIDTH,
       height: gameConfig.MAP_HEIGHT

--- a/backend/services/GameService.js
+++ b/backend/services/GameService.js
@@ -5,6 +5,7 @@ class GameService {
   constructor() {
     this.games = {};
     this.projectileId = 0;
+    this.projectileTimers = {};
   }
 
   createGame(gameId, gameName, ownerUsername) {
@@ -27,6 +28,13 @@ class GameService {
     };
 
     this.games[gameId] = game;
+
+    // Start per-game projectile update timer
+    const interval = setInterval(() => {
+      this.updateProjectiles(gameId);
+    }, 1000 / config.game.tickRate);
+    this.projectileTimers[gameId] = interval;
+
     logger.info(`Game created: ${gameName} by ${ownerUsername}`);
     
     return game;
@@ -95,6 +103,8 @@ class GameService {
 
     // Remove empty games (except if owner is still there)
     if (Object.keys(game.players).length === 0) {
+      clearInterval(this.projectileTimers[gameId]);
+      delete this.projectileTimers[gameId];
       delete this.games[gameId];
       logger.info(`Game ${game.name} removed (empty)`);
     }

--- a/backend/socket/SocketHandler.js
+++ b/backend/socket/SocketHandler.js
@@ -40,10 +40,6 @@ class SocketHandler {
       });
     });
 
-    // Update projectiles for all games every 16ms (~60fps)
-    setInterval(() => {
-      this.updateAllProjectiles();
-    }, 16);
   }
 
   async handleGameInit(socket, data) {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -42,6 +42,9 @@ module.exports = {
   // Game mechanics
   PROJECTILE_SPEED: 5,
   PLAYER_SPEED: 3,
+
+  // Timing
+  GAME_TICK_RATE: 60, // server updates per second
   
   // Game balance
   PLAYER_HEALTH: 100,
@@ -52,6 +55,10 @@ module.exports = {
   MAP_HEIGHT: 600
 };
 ```
+
+The `GAME_TICK_RATE` controls how often the server updates game state. Each game
+instance starts its own timer based on this rate (`config.game.tickRate`) to
+process projectile movement and other periodic logic.
 
 ## Why This Separation?
 

--- a/test/gameService.test.js
+++ b/test/gameService.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const GameService = require('../backend/services/GameService');
+
+describe('GameService projectile timers', function() {
+  it('starts and clears timers when games are created and removed', function() {
+    const service = new GameService();
+    const gameId = 'test-' + Date.now();
+    // create game
+    service.createGame(gameId, 'Test Game', 'owner');
+    assert.ok(service.projectileTimers[gameId], 'timer should be started');
+
+    // add then remove a player to trigger game cleanup
+    service.addPlayerToGame(gameId, 'socket1', { username: 'p1', width: 800, height: 600 });
+    service.removePlayerFromGame(gameId, 'socket1');
+
+    assert.strictEqual(service.projectileTimers[gameId], undefined, 'timer should be cleared');
+  });
+});


### PR DESCRIPTION
## Summary
- surface tick rate constant through backend config
- run projectile updates per game with individual timers
- drop global timer from socket handler
- document tick rate usage in CONFIGURATION.md
- test that game timers start and stop properly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867bbd04974832aad2992a31d1fbed6