### PR TITLE
Fix missing guest names module error

### DIFF
--- a/frontend/public/js/login.js
+++ b/frontend/public/js/login.js
@@ -1,5 +1,4 @@
 // Sci-fi themed guest names shared with the backend
-import GUEST_NAMES from '../../../shared/guestNames.js';
 
 async function postJSON(url, data) {
   const res = await fetch(url, {


### PR DESCRIPTION
## Summary
- remove unused `guestNames.js` import that caused 404

## Testing
- `npx mocha test/**/*.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6867bfb15914832a87903035f2239ea7